### PR TITLE
Fixed firmware build on Mac OS / *BSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 eagle/*#*
 .DS_Store
+*.elf
+*.hex
 *.swp
 *.pyc

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -53,9 +53,9 @@ write_fuses:
 eeprom_id: LAYOUT_VERSION:=01
 eeprom_id: PROTO_VERSION:=01
 eeprom_id: EEPROM_SIZE:=40
-eeprom_id: MODEL:=$(shell head --bytes=2 /dev/urandom |hexdump -v -e '/1 "%02X"')
-eeprom_id: SERIALNO:=$(shell head --bytes=3 /dev/urandom |hexdump -v -e '/1 "%02X"')
-eeprom_id: REVISION:=$(shell head --bytes=1 /dev/urandom |hexdump -v -e '/1 "%02X"')
+eeprom_id: MODEL:=$(shell head -c2 /dev/urandom |hexdump -v -e '/1 "%02X"')
+eeprom_id: SERIALNO:=$(shell head -c3 /dev/urandom |hexdump -v -e '/1 "%02X"')
+eeprom_id: REVISION:=$(shell head -c1 /dev/urandom |hexdump -v -e '/1 "%02X"')
 eeprom_id: ID:=$(PROTO_VERSION)$(MODEL)$(REVISION)$(SERIALNO)
 eeprom_id: CHECKSUM:=$(shell printf "%02x" $$(pycrc --width=8 --poly=0x2f --xor-in=0 --reflect-in=false --reflect-out=false --xor-out=0 --check-hexstring $(ID)))
 eeprom_id: DATA=$(shell echo $(LAYOUT_VERSION)$(EEPROM_SIZE)$(ID)$(CHECKSUM) | tr '[:upper:]' '[:lower:]' | sed 's/../0x& /g')


### PR DESCRIPTION
Quick fix for Mac OS compatibility. Other implementations of head don't support long options like GNU/Linux
does.

Also, it might be nice to document where to find the pycrc dependency or possibly reference it as a submodule. I found git@github.com:tpircher/pycrc.git which seems to fit the bill.
